### PR TITLE
Added Markdown Previewer project

### DIFF
--- a/MarkdownPreviewer/rajdeepdev10/README.md
+++ b/MarkdownPreviewer/rajdeepdev10/README.md
@@ -1,0 +1,5 @@
+# Markdown Previewer
+
+Converts Markdown code to HTML and previews in the browser using [Marked library](https://cdnjs.com/libraries/marked).
+
+[Link](https://rajdeepdev10.github.io/markdown_previewer) to Github Pages

--- a/MarkdownPreviewer/rajdeepdev10/index.html
+++ b/MarkdownPreviewer/rajdeepdev10/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-giJF6kkoqNQ00vy+HMDP7azOuL0xtbfIcaT9wjKHr8RbDVddVHyTfAAsrekwKmP1" crossorigin="anonymous">
+        <link rel="stylesheet" type="text/css" href="./style.css">
+        <title>Markdown Previewer</title>
+    </head>
+    <body>
+        <h1 class="text-center p-3 mb-2 bg-primary text-white">Markdown Previewer</h1>
+
+        <div class="container">
+            <div class="row">
+                <div class="col-6">
+                    <textarea id="editor"></textarea>
+                </div>
+                <div class="col-6">
+                    <div id="preview"></div>
+                </div>
+            </div>
+          </div>
+        <script src="./script.js"></script>
+        <!--Marked script-->
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/1.2.7/marked.min.js" integrity="sha512-Sl04EWeJ0QgILm83WoubQbZqh71aWLJP8xnswnKSBI37S+ZtrWVtSHmd1YaYYdC1g9PWN1siY7KO2jU3HtCVHA==" crossorigin="anonymous"></script>
+        <!--Bootstrap script-->
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/js/bootstrap.bundle.min.js" integrity="sha384-ygbV9kiqUc6oa4msXn9868pTtWMgiQaeYH7/t7LECLbyPA2x65Kgf80OJFdroafW" crossorigin="anonymous"></script>
+    </body>
+</html>

--- a/MarkdownPreviewer/rajdeepdev10/script.js
+++ b/MarkdownPreviewer/rajdeepdev10/script.js
@@ -1,0 +1,45 @@
+const editor_txtarea = document.getElementById("editor");
+const preview_div = document.getElementById("preview");
+
+editor_txtarea.addEventListener("keyup", function(){
+    preview_div.innerHTML = marked(editor_txtarea.value);
+});
+
+function initialMarkdown()
+{
+    editor_txtarea.value = `\
+# Markdown Previewer
+## version 0.1.0 
+
+Enter Markdown code in the \`<textarea>\` to preview the syntax
+
+Here's the basic source code that makes it all work:
+\`\`\`
+const editor_txtarea = document.getElementById("editor");
+const preview_div = document.getElementById("preview");
+
+editor_txtarea.addEventListener("keyup", function(){
+    preview_div.innerHTML = marked(editor_txtarea.value);
+});
+\`\`\`
+It uses the \`marked()\` function from the [Marked library](https://cdnjs.com/libraries/marked)
+
+This function converts **Markdown** syntax to pure **HTML**
+
+This project is part of **FreeCodeCamp Front End Libraries certifications** and to pass user stories I need examples of
+
+> A block Quote
+
+- A list item 
+
+and an image:
+
+![To Dare is To Do](http://blogs.ubc.ca/rajdeepdev/files/2020/12/s-l1600-1.jpg)
+
+`;
+    preview_div.innerHTML = marked(editor_txtarea.value);
+}
+
+window.onload = function(){
+    initialMarkdown();
+};

--- a/MarkdownPreviewer/rajdeepdev10/style.css
+++ b/MarkdownPreviewer/rajdeepdev10/style.css
@@ -1,0 +1,7 @@
+textarea
+{
+    width: 100%;
+    height: 100vh;
+}
+
+  


### PR DESCRIPTION
I've added a Markdown Previewer project that can preview Markdown code using javascript. It uses [Marked librart](https://cdnjs.com/libraries/marked) to convert Markdown to HTML. This project also uses Bootstrap. 


![Screenshot from 2021-10-13 21-40-36](https://user-images.githubusercontent.com/65982347/137232057-44049f35-83f2-49a7-a61b-59279329d03a.png)

