### PR TITLE
Fix: Prevent multiple decimal errors in input calculator

### DIFF
--- a/Calculator/Pratik1968/main.js
+++ b/Calculator/Pratik1968/main.js
@@ -2,13 +2,12 @@ let value = ""
 
 let ans = 0
 
-
 function setInput() {
     let input = document.getElementById("ans");
     input.value = value
 }
 
-window.onload = function() {
+window.onload = function () {
     setInput()
 }
 
@@ -22,7 +21,6 @@ function NumberButtonClick(number) {
         value += number
     }
 
-
     setInput()
 }
 
@@ -35,7 +33,6 @@ function isOperator(value) {
 }
 
 function functionButton(Function) {
-
     let input = document.getElementById("ans");
     if (input.value == "" || input.value == null) { return; }
     let lastChar = value[value.length - 1];
@@ -43,7 +40,6 @@ function functionButton(Function) {
     if (isOperator(lastChar) && Function !== '8') {
         return;
     }
-
 
     switch (Function) {
         case functionVar.add:
@@ -59,7 +55,12 @@ function functionButton(Function) {
                 value += "x";
             break;
         case functionVar.equal:
-            ans = eval(value.replace("x", "*").replace("%", "*1/100").replace("^", "**"));
+            ans = eval(
+                value
+                    .replace(/x/g, "*")
+                    .replace(/%/g, "*1/100")
+                    .replace(/\^/g, "**")
+            );
             value = ans;
             break;
         case functionVar.division:
@@ -81,12 +82,15 @@ function functionButton(Function) {
             value = value.slice(0, -1)
             break;
         case functionVar.decimal:
-            if (lastChar !== "." && !value.includes('.'))
+            let parts = value.split(/[\+\-\x\/\%\^]/); // split by any operator
+            let currentPart = parts[parts.length - 1];
+
+            if (!currentPart.includes(".")) {
                 value += ".";
+            }
             break;
+
     }
 
-
     setInput()
-
 }


### PR DESCRIPTION
  What was wrong?
 A decimal was only permitted by the logic if there were no dots in the entire input.
 For instance, after typing `3.5 +`, it was not possible to enter another decimal, such as `2.4`.
 -  This limited valid decimal inputs and caused incorrect validation.

  What's fixed?
 Decimal validation has been updated to: - Permit one decimal per number segment - Prevent multiple decimals in the same number - Maintain current functionality

  Tested:  (Correctly blocked) single number multiple decimals
 Multi-number decimals ✔ (Working) - Decimals + mixed operations ✔

 This fix enhances the calculator's accuracy and usability without changing its fundamental functionality.
<img width="1920" height="1080" alt="Screenshot (2)" src="https://github.com/user-attachments/assets/daed2d48-0a9c-4cac-b7fb-c2370231b657" />


